### PR TITLE
Force VM versions to minimum required version

### DIFF
--- a/vSphere/centos_7/centos7.json
+++ b/vSphere/centos_7/centos7.json
@@ -9,6 +9,7 @@
         "insecure_connection": "true",
   
         "vm_name": "template_centos7",
+        "vm_version": "15",
         "datastore": "{{user `datastore`}}",
         "folder": "{{user `folder`}}",
         "host":     "{{user `host`}}",

--- a/vSphere/ubuntu_1804/ubuntu-18.json
+++ b/vSphere/ubuntu_1804/ubuntu-18.json
@@ -9,6 +9,7 @@
         "insecure_connection": "true",
   
         "vm_name": "template_ubuntu18test",
+        "vm_version": "15",
         "datastore": "{{user `datastore`}}",
         "folder": "{{user `folder`}}",
         "host":     "{{user `host`}}",

--- a/vSphere/ubuntu_1804_no_dhcp/ubuntu-18.json
+++ b/vSphere/ubuntu_1804_no_dhcp/ubuntu-18.json
@@ -10,6 +10,7 @@
   
         "vm_name": "template_ubuntu18_nodhcp",
         "datastore": "{{user `datastore`}}",
+        "vm_version": "15",
         "folder": "{{user `folder`}}",
         "host":     "{{user `host`}}",
         "convert_to_template": "true",


### PR DESCRIPTION
I noticed Rancher recommends VM versions 15.

https://rancher.com/blog/2020/stateful-kubernetes-workloads

Another approach would be to add a section in the README to give people a heads-up.