### PR TITLE
Fixes for the standard Ubuntu 18.04 template

### DIFF
--- a/vSphere/ubuntu_1804/preseed.cfg
+++ b/vSphere/ubuntu_1804/preseed.cfg
@@ -6,7 +6,17 @@ d-i user-setup/allow-password-weak boolean true
 
 d-i partman-auto/disk string /dev/sda
 d-i partman-auto/method string regular
-d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-swapfile/size string 0
+d-i partman-auto/expert_recipe string root :: 1000 50 -1 ext4 \
+     $primary{ } $bootable{ } method{ format } \
+     format{ } use_filesystem{ } filesystem{ ext4 } \
+     mountpoint{ / } \
+     .
+d-i partman-auto/choose_recipe select root
+d-i partman/choose_partition select Finish partitioning and write changes to disk
+d-i partman/confirm boolean true
+d-i partman/confirm_write_new_label boolean true
 d-i partman/choose_partition select finish
 d-i partman/confirm boolean true
 d-i partman/confirm_nooverwrite boolean true

--- a/vSphere/ubuntu_1804/script.sh
+++ b/vSphere/ubuntu_1804/script.sh
@@ -1,5 +1,27 @@
+# Apply updates and cleanup Apt cache
+#
+apt-get update ; apt-get -y dist-upgrade
+apt-get -y autoremove
+apt-get -y clean
+
 # Reset the machine-id value. This has known to cause issues with DHCP
+#
 echo -n > /etc/machine-id
 
+# Create a swapfile
+#
+fallocate -l 2G /.swap
+chmod 0600 /.swap
+mkswap /.swap
+echo '/.swap    swap    swap    default    0   0' >> /etc/fstab
+
 # Reset any existing cloud-init state
-cloud-init clean --logs
+#
+cloud-init clean -s -l
+
+## Final clean up
+## Zero out the free space to save space in the final image
+##
+#dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
+#rm -f /EMPTY
+#sync

--- a/vSphere/ubuntu_1804/ubuntu-18.json
+++ b/vSphere/ubuntu_1804/ubuntu-18.json
@@ -1,72 +1,70 @@
 {
-    "builders": [
-      {
-        "type": "vsphere-iso",
-  
-        "vcenter_server":      "{{user `vcenter_server`}}",
-        "username":            "{{user `username`}}",
-        "password":            "{{user `password`}}",
-        "insecure_connection": "true",
-  
-        "vm_name": "template_ubuntu18test",
-        "datastore": "{{user `datastore`}}",
-        "folder": "{{user `folder`}}",
-        "host":     "{{user `host`}}",
-        "convert_to_template": "true",
-        "cluster": "{{user `cluster`}}",
-        "network": "{{user `network`}}",
-        "boot_order": "disk,cdrom",
-  
-        "guest_os_type": "ubuntu64Guest",
-  
-        "ssh_username": "{{user `ssh_username`}}",
-        "ssh_password": "{{user `ssh_password`}}",
-  
-        "CPUs":             2,
-        "RAM":              2048,
-        "RAM_reserve_all": true,
-  
-        "disk_controller_type":  "pvscsi",
-        "disk_size":        32768,
-        "disk_thin_provisioned": true,
-  
-        "network_card": "vmxnet3",
-  
-        "iso_urls": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-amd64.iso",
-        "iso_checksum": "d5bc5c59c24191bb45dd85fc6a420b34",
-        "iso_checksum_type": "MD5",
+  "builders": [
+    {
+      "CPUs": 2,
+      "RAM": 2048,
+      "RAM_reserve_all": true,
+      "boot_command": [
+        "<enter><wait><f6><wait><esc><wait>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs>",
+        "/install/vmlinuz",
+        " initrd=/install/initrd.gz",
+        " priority=critical",
+        " locale=en_US",
+        " file=/media/preseed.cfg",
+        "<enter>"
+      ],
+      "boot_order": "disk,cdrom",
+      "cluster": "{{user `cluster`}}",
+      "convert_to_template": "true",
+      "datastore": "{{user `datastore`}}",
+      "disk_controller_type": "pvscsi",
+      "floppy_files": [
+        "./preseed.cfg"
+      ],
+      "folder": "{{user `folder`}}",
+      "guest_os_type": "ubuntu64Guest",
+      "host": "{{user `host`}}",
+      "insecure_connection": "true",
+      "iso_checksum": "MD5:d5bc5c59c24191bb45dd85fc6a420b34",
+      "iso_urls": "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04.4-server-amd64.iso",
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "vmxnet3"
+        }
+      ],
+      "password": "{{user `password`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "storage": [
+        {
+          "disk_size": 8192,
+          "disk_thin_provisioned": true
+        }
+      ],
+      "type": "vsphere-iso",
+      "username": "{{user `username`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "vm_name": "template_ubuntu1804"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "script.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}
 
-        "floppy_files": [
-          "./preseed.cfg"
-        ],
-        "boot_command": [
-          "<enter><wait><f6><wait><esc><wait>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
-          "<bs><bs><bs>",
-          "/install/vmlinuz",
-          " initrd=/install/initrd.gz",
-          " priority=critical",
-          " locale=en_US",
-          " file=/media/preseed.cfg",
-          "<enter>"
-        ]
-      }
-    ],
-  
-    "provisioners": [
-      {
-        "type": "shell",
-        "execute_command":       "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
-        "scripts" : [
-          "script.sh"
-        ]
-      }
-    ]
-  }


### PR DESCRIPTION
This commit fixes the standard Ubuntu 18.04 template to resolve compatibility issues with newer releases of Packer.

It also updates the default partitioning configuration so that the root disk is resized according to what's requested via cloud-init, and configures a swapfile instead of a dedicated partition.

Tested with Packer v1.6.0 and vSphere 7.0.