### PR TITLE
Add support for building a Ubuntu 20.04 image

### DIFF
--- a/vSphere/ubuntu_2004/preseed.cfg
+++ b/vSphere/ubuntu_2004/preseed.cfg
@@ -1,0 +1,36 @@
+d-i passwd/user-fullname string packerbuilt
+d-i passwd/username string packerbuilt
+d-i passwd/user-password password PackerBuilt!
+d-i passwd/user-password-again password PackerBuilt!
+d-i user-setup/allow-password-weak boolean true
+
+d-i partman-auto/disk string /dev/sda
+d-i partman-auto/method string regular
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-swapfile/size string 0
+d-i partman-auto/expert_recipe string root :: 1000 50 -1 ext4 \
+     $primary{ } $bootable{ } method{ format } \
+     format{ } use_filesystem{ } filesystem{ ext4 } \
+     mountpoint{ / } \
+     .
+d-i partman-auto/choose_recipe select root
+d-i partman/choose_partition select Finish partitioning and write changes to disk
+d-i partman/confirm boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+
+d-i passwd/root-login boolean true
+d-i passwd/root-password password PackerBuilt!
+d-i passwd/root-password-again password PackerBuilt!
+
+d-i pkgsel/include string open-vm-tools openssh-server cloud-init
+
+d-i grub-installer/only_debian boolean true
+
+d-i preseed/late_command string \
+    echo 'packerbuilt ALL=(ALL) NOPASSWD: ALL' > /target/etc/sudoers.d/packerbuilt ; \
+    in-target chmod 440 /etc/sudoers.d/packerbuilt ;
+
+d-i finish-install/reboot_in_progress note

--- a/vSphere/ubuntu_2004/script.sh
+++ b/vSphere/ubuntu_2004/script.sh
@@ -1,0 +1,23 @@
+# Apply updates and cleanup Apt cache
+#
+apt-get update ; apt-get -y dist-upgrade
+apt-get -y autoremove
+apt-get -y clean
+
+# Create a swapfile
+#
+fallocate -l 2G /.swap
+chmod 0600 /.swap
+mkswap /.swap
+echo '/.swap    swap    swap    default    0   0' >> /etc/fstab
+
+# Reset the machine-id value. This has known to cause issues with DHCP
+#
+truncate -s 0 /etc/machine-id
+rm /var/lib/dbus/machine-id
+ln -s /etc/machine-id /var/lib/dbus/machine-id
+
+# Reset any existing cloud-init state
+#
+cloud-init clean -s -l
+

--- a/vSphere/ubuntu_2004/ubuntu-2004.json
+++ b/vSphere/ubuntu_2004/ubuntu-2004.json
@@ -1,0 +1,70 @@
+{
+  "builders": [
+    {
+      "CPUs": 2,
+      "RAM": 2048,
+      "RAM_reserve_all": true,
+      "boot_command": [
+        "<enter><wait><f6><wait><esc><wait>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs><bs><bs><bs><bs><bs><bs><bs>",
+        "<bs><bs><bs>",
+        "/install/vmlinuz",
+        " initrd=/install/initrd.gz",
+        " priority=critical",
+        " locale=en_US",
+        " file=/media/preseed.cfg",
+        "<enter>"
+      ],
+      "boot_order": "disk,cdrom",
+      "cluster": "{{user `cluster`}}",
+      "convert_to_template": "true",
+      "datastore": "{{user `datastore`}}",
+      "disk_controller_type": "pvscsi",
+      "floppy_files": [
+        "./preseed.cfg"
+      ],
+      "folder": "{{user `folder`}}",
+      "guest_os_type": "ubuntu64Guest",
+      "host": "{{user `host`}}",
+      "insecure_connection": "true",
+      "iso_checksum": "MD5:9d2b54506f8f9fdad6b72e45aff0f0de",
+      "iso_urls": "http://cdimage.ubuntu.com/ubuntu-legacy-server/releases/20.04/release/ubuntu-20.04-legacy-server-amd64.iso",
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "vmxnet3"
+        }
+      ],
+      "password": "{{user `password`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "storage": [
+        {
+          "disk_size": 8192,
+          "disk_thin_provisioned": true
+        }
+      ],
+      "type": "vsphere-iso",
+      "username": "{{user `username`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "vm_name": "template_ubuntu2004"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "script.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}
+

--- a/vSphere/ubuntu_2004/variables.json.example
+++ b/vSphere/ubuntu_2004/variables.json.example
@@ -1,0 +1,12 @@
+{
+    "vcenter_server":"",
+    "username":"administrator@vsphere.local",
+    "password":"",
+    "datastore":"",
+    "folder": "",
+    "host":"",
+    "cluster": "",
+    "network": "",
+    "ssh_username": "packerbuilt",
+    "ssh_password": "PackerBuilt!"
+}


### PR DESCRIPTION
This commit adds the Packer template and configuration necessary to build a Ubuntu 20.04-based image.

Tested with Packer v1.6.0 and vSphere 7.0.