### PR TITLE
CentOS 7 template fixes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,15 +11,16 @@ This repo contains Packer templates suitable to create RKE VM's for a number of 
 
 ## Current Templates
 
-## vSphere
+### vSphere
 
 [Ubuntu 18.04](https://github.com/David-VTUK/Rancher-Packer/tree/master/vSphere/ubuntu_1804) - Includes logic to address cloud-init depedency and resolves DHCP issues (cloned VM's receiving the same DHCP address.)
 
 [Ubuntu 18.04 - No DHCP](https://github.com/David-VTUK/Rancher-Packer/tree/master/vSphere/ubuntu_1804_no_dhcp) - Forces not to accept DHCP. 
 
+[Ubuntu 20.04](https://github.com/David-VTUK/Rancher-Packer/tree/master/vSphere/ubuntu_2004)
+
 [CentOS 7](https://github.com/David-VTUK/Rancher-Packer/tree/master/vSphere/centos_7)
 
 ## To do
 
-* Ubuntu 20.04
-* CentOS
+* CentOS 8

--- a/vSphere/centos_7/centos7.json
+++ b/vSphere/centos_7/centos7.json
@@ -1,55 +1,53 @@
 {
-    "builders": [
-      {
-        "type": "vsphere-iso",
-  
-        "vcenter_server":      "{{user `vcenter_server`}}",
-        "username":            "{{user `username`}}",
-        "password":            "{{user `password`}}",
-        "insecure_connection": "true",
-  
-        "vm_name": "template_centos7",
-        "datastore": "{{user `datastore`}}",
-        "folder": "{{user `folder`}}",
-        "host":     "{{user `host`}}",
-        "convert_to_template": "true",
-        "cluster": "{{user `cluster`}}",
-        "network": "{{user `network`}}",
-        "boot_order": "disk,cdrom",
-  
-        "guest_os_type": "centos7_64Guest",
-  
-        "ssh_username": "{{user `ssh_username`}}",
-        "ssh_password": "{{user `ssh_password`}}",
-  
-        "CPUs":             2,
-        "RAM":              2048,
-        "RAM_reserve_all": true,
-  
-        "disk_controller_type":  "pvscsi",
-        "disk_size":        32768,
-        "disk_thin_provisioned": true,
-  
-        "network_card": "vmxnet3",
+  "builders": [
+    {
+      "CPUs": 2,
+      "RAM": 2048,
+      "RAM_reserve_all": true,
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+      ],
+      "boot_order": "disk,cdrom",
+      "cluster": "{{user `cluster`}}",
+      "convert_to_template": "true",
+      "datastore": "{{user `datastore`}}",
+      "disk_controller_type": "pvscsi",
+      "folder": "{{user `folder`}}",
+      "guest_os_type": "centos7_64Guest",
+      "host": "{{user `host`}}",
+      "http_directory": "./http",
+      "insecure_connection": "true",
+      "iso_checksum": "SHA256:101bc813d2af9ccf534d112cbe8670e6d900425b297d1a4d2529c5ad5f226372",
+      "iso_urls": "http://mirror.bytemark.co.uk/centos/7.8.2003/isos/x86_64/CentOS-7-x86_64-NetInstall-2003.iso",
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "vmxnet3"
+        }
+      ],
+      "password": "{{user `password`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "storage": [
+        {
+          "disk_size": 8192,
+          "disk_thin_provisioned": true
+        }
+      ],
+      "type": "vsphere-iso",
+      "username": "{{user `username`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "vm_name": "template_centos7"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "script.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}
 
-        "http_directory": "./http",
-  
-        "iso_urls": "http://mirror.ox.ac.uk/sites/mirror.centos.org/7.8.2003/isos/x86_64/CentOS-7-x86_64-DVD-2003.iso",
-        "iso_checksum": "087a5743dc6fd6706d9b961b8147423ddc029451b938364c760d75440eb7be14",
-        "iso_checksum_type": "SHA256",
-
-        "boot_command": [
-          "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
-        ]
-      }
-    ],
-    "provisioners": [
-      {
-        "type": "shell",
-        "execute_command": "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
-        "scripts" : [
-          "script.sh"
-        ]
-      }
-    ]
-  }

--- a/vSphere/centos_7/http/ks.cfg
+++ b/vSphere/centos_7/http/ks.cfg
@@ -1,23 +1,25 @@
 install
 cdrom
 lang en_GB
-keyboard --vckeymap=uk --xlayouts='gb'
 network --bootproto=dhcp --activate
 rootpw PackerBuilt!
 firewall --disabled
 selinux --permissive
 timezone Europe/London --isUtc
+url --url=http://mirror.centos.org/centos/7/os/x86_64/
+repo --name=centos7-x86_64-extras --baseurl=http://mirror.centos.org/centos/7/extras/x86_64/
 bootloader --location=mbr
 text
 skipx
 zerombr
 clearpart --all --initlabel
-autopart --type=lvm
+part / --asprimary --fstype ext4 --label=root --fsprofile=ext4 --size 1024 --grow
 auth --enableshadow --passalgo=sha512 --kickstart
 firstboot --disabled
 eula --agreed
 services --enabled=NetworkManager,sshd
 reboot
+user --name=packerbuilt --plaintext --password=PackerBuilt! --groups=wheel
 
 %packages --ignoremissing --excludedocs
 @core
@@ -28,6 +30,8 @@ ntpdate
 vim
 wget
 curl
+cloud-init
+cloud-utils-growpart
 
 # unnecessary firmware
 -aic94xx-firmware
@@ -59,4 +63,17 @@ curl
 %end
 
 %post
+yum update -y
+
+fallocate -l 2G /.swap
+chmod 0600 /.swap
+mkswap /.swap
+echo '/.swap    swap    swap    default    0   0' >> /etc/fstab
+
+sed "s/^ssh_pwauth.*/ssh_pwauth: True/g" -i /etc/cloud/cloud.cfg
+sed "s/PasswordAuthentication no/PasswordAuthentication yes/g" -i /etc/ssh/sshd_config
+echo "packerbuilt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/packerbuilt
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+yum clean all
 %end

--- a/vSphere/centos_7/script.sh
+++ b/vSphere/centos_7/script.sh
@@ -1,2 +1,7 @@
-# Install cloud-init
-yum install -y cloud-init
+# Reset the machine-id value. This has known to cause issues with DHCP
+#
+echo -n > /etc/machine-id
+
+# Reset any existing cloud-init state
+#
+cloud-init clean -s -l

--- a/vSphere/ubuntu_1804/script.sh
+++ b/vSphere/ubuntu_1804/script.sh
@@ -19,9 +19,3 @@ echo '/.swap    swap    swap    default    0   0' >> /etc/fstab
 #
 cloud-init clean -s -l
 
-## Final clean up
-## Zero out the free space to save space in the final image
-##
-#dd if=/dev/zero of=/EMPTY bs=1M  || echo "dd exit code $? is suppressed"
-#rm -f /EMPTY
-#sync


### PR DESCRIPTION
Update the CentOS 7 template for the following:

* Packer 1.6.0 compatibility
* Fix root partition auto-resizing
* Use CentOS netboot ISO to speed to build

Other notable changes:

* Default filesystem changed from XFS to ext4
* Single root partition with a 2GB swapfile

Tested with Packer v1.6.0 and vSphere 7.0.