### PR TITLE
Added Rhel7 and Rhel8 builds

### DIFF
--- a/vSphere/rhel_7/.gitignore
+++ b/vSphere/rhel_7/.gitignore
@@ -1,0 +1,14 @@
+# Cache objects
+packer_cache/
+
+# Crash log
+crash.log
+
+# For built boxes
+*.box
+
+# Config file
+variables.json
+
+# Downloaded iso's
+*.iso

--- a/vSphere/rhel_7/http/ks.cfg
+++ b/vSphere/rhel_7/http/ks.cfg
@@ -1,0 +1,104 @@
+#version=RHEL8
+ignoredisk --only-use=sda
+# Partition clearing information
+clearpart --none --initlabel
+# Use graphical install
+graphical
+# Use CDROM installation media
+cdrom
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network  --bootproto=dhcp --device=ens192 --ipv6=auto --activate
+network  --hostname=localhost.localdomain
+#Repo
+repo --name="AppStream" --baseurl=file:///run/install/repo/AppStream
+# Root password
+rootpw packerbuilt!
+# Run the Setup Agent on first boot
+firstboot --disable
+# Eula
+eula --agreed
+# Do not configure the X Window System
+skipx
+# Disable Firewall
+firewall --disabled
+# Selinux permissive
+selinux --permissive
+# System services
+services --enabled="chronyd,sshd"
+# System timezone
+timezone America/New_York --isUtc
+# Disk partitioning information
+part / --fstype="xfs" --ondisk=sda --size=20000 
+reboot
+user --name=packerbuilt --plaintext --password=packerbuilt! --groups=wheel
+
+%packages
+@^minimal
+@core
+kexec-tools
+chrony
+sudo
+net-tools
+vim
+wget
+curl
+cloud-init
+cloud-utils-growpart
+
+# unnecessary firmware
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
+%anaconda
+pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty
+pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --notempty
+%end
+
+%post
+yum update -y
+
+fallocate -l 2G /.swap
+chmod 0600 /.swap
+mkswap /.swap
+echo '/.swap    swap    swap    default    0   0' >> /etc/fstab
+
+sed "s/^ssh_pwauth.*/ssh_pwauth: True/g" -i /etc/cloud/cloud.cfg
+sed "s/PasswordAuthentication no/PasswordAuthentication yes/g" -i /etc/ssh/sshd_config
+echo "packerbuilt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/packerbuilt
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+yum clean all
+%end

--- a/vSphere/rhel_7/readme.md
+++ b/vSphere/rhel_7/readme.md
@@ -1,0 +1,13 @@
+#Rhel 7 clean template
+This should build a usable Rancher Template
+
+It does have the code for an internal proxy - just remove that configuration if its not needed.
+
+Please edit the following:
+* script.sh
+* variables.json
+* rhel7.json 
+
+Replace values for proxy (if needed), docker server repo if you have it local, domain names for subscription, and your local Red Hat Satellite Server if its on prem. 
+
+

--- a/vSphere/rhel_7/rhel7.json
+++ b/vSphere/rhel_7/rhel7.json
@@ -1,0 +1,53 @@
+{
+  "builders": [
+    {
+      "CPUs": 2,
+      "RAM": 3192,
+      "RAM_reserve_all": true,
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+      ],
+      "boot_order": "disk,cdrom",
+      "cluster": "{{user `cluster`}}",
+      "convert_to_template": "true",
+      "datastore": "{{user `datastore`}}",
+      "disk_controller_type": "pvscsi",
+      "folder": "{{user `folder`}}",
+      "guest_os_type": "centos7_64Guest",
+      "host": "{{user `host`}}",
+      "http_directory": "./http",
+      "insecure_connection": "true",
+      "iso_checksum": "SHA256:3ca2017f12392fc8acad435c05a941bb88620ece8eb5740278ffa61d8340792d",
+      "iso_urls": "http://<<your_repo_server>>/iso/rhel-server-7.8-x86_64-dvd.iso",
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "vmxnet3"
+        }
+      ],
+      "password": "{{user `password`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "storage": [
+        {
+          "disk_size": 20480,
+          "disk_thin_provisioned": true
+        }
+      ],
+      "type": "vsphere-iso",
+      "username": "{{user `username`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "vm_name": "{{user `vm_image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "script.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}
+

--- a/vSphere/rhel_7/script.sh
+++ b/vSphere/rhel_7/script.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# purge files to make sure since we are going to recreate them
+rm /etc/rhsm/facts/katello.facts
+rm /etc/yum.repos.d/docker.repo
+rm /etc/environment
+rm /etc/systemd/system/docker.service.d/https-proxy.conf
+rm /etc/profile.d/proxy.sh
+
+# Proxy stuff
+cat <<EOT >> /etc/profile.d/proxy.sh
+export HTTP_PROXY=http://<<proxy_server>>:8080
+export HTTPS_PROXY=http://<<proxy_server>>:8080
+export http_proxy=http://<<proxy_server>>:8080
+export https_proxy=http://<<proxy_server>>:8080
+EOT
+
+cat <<EOT >> /etc/environment
+http_proxy=http://<<proxy_server>>:8080
+https_proxy=http://<<proxy_server>>:8080
+HTTP_PROXY=http://<<proxy_server>>:8080
+HTTPS_PROXY=http://<<proxy_server>>:8080
+EOT
+
+mkdir /etc/systemd/system/docker.service.d
+cat <<EOT >> /etc/systemd/system/docker.service.d/https-proxy.conf
+[Service]
+Environment="HTTP_PROXY=http://<<proxy_server>>:8080/"
+Environment="HTTPS_PROXY=http://<<proxy_server>>:8080/"
+Environment="NO_PROXY=<<rancher_url>>,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+EOT
+
+# Do subscription manager stuff and update packages
+cat <<EOT >> /etc/rhsm/facts/katello.facts
+{"network.hostname-override":"<<yourdomain>>.local"}
+EOT
+
+rpm -Uvh http://<<your_rsat_server>>/pub/katello-ca-consumer-latest.noarch.rpm
+subscription-manager register --org="<<org_name>>" --activationkey='<<activation_key>>'
+subscription-manager repos --enable=rhel-7-server-extras-rpms
+yum -y install vim nano net-tools bind-utils
+yum -y update
+
+cat <<EOT >> /etc/yum.repos.d/docker.repo
+[docker-ce-stable]
+name=Docker CE Stable - $basearch
+baseurl=http://<<your_repo_server>>/docker-ce-stable-upstream/
+failovermethod=priority
+enabled=1
+gpgcheck=0
+EOT
+
+yum clean packages
+yum clean metadata
+yum clean all
+
+yum -y install container-selinux
+#yum -y install containerd.io
+#The upstream has an issue where containerd.io is hidden from the system in yum
+yum -y --disablerepo="*" --enablerepo=docker-ce-stable install http://<<your_repo_server>>/docker-ce-stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
+yum -y install docker-ce docker-ce-selinux
+systemctl daemon-reload
+service docker restart
+systemctl enable docker
+
+subscription-manager unregister
+
+docker run hello-world
+docker rm $(docker ps -a -f status=exited -f status=created -q)
+docker rmi $(docker images -a -q)
+
+# Reset the machine-id value. This has known to cause issues with DHCP
+#
+echo -n > /etc/machine-id
+
+# Reset any existing cloud-init state
+#
+cloud-init clean -s -l
+

--- a/vSphere/rhel_7/variables.json.example
+++ b/vSphere/rhel_7/variables.json.example
@@ -1,0 +1,13 @@
+{
+    "vcenter_server":"",
+    "username":"administrator@vsphere.local",
+    "password":"",
+    "datastore":"",
+    "folder": "",
+    "host":"",
+    "cluster": "",
+    "network": "",
+    "ssh_username": "root",
+    "ssh_password": "PackerBuilt!",
+    "vm_image_name" "rhel_7_packer_image"
+}

--- a/vSphere/rhel_8/.gitignore
+++ b/vSphere/rhel_8/.gitignore
@@ -1,0 +1,14 @@
+# Cache objects
+packer_cache/
+
+# Crash log
+crash.log
+
+# For built boxes
+*.box
+
+# Config file
+variables.json
+
+# Downloaded iso's
+*.iso

--- a/vSphere/rhel_8/http/ks.cfg
+++ b/vSphere/rhel_8/http/ks.cfg
@@ -1,0 +1,103 @@
+#version=RHEL8
+ignoredisk --only-use=sda
+# Partition clearing information
+clearpart --none --initlabel
+# Use graphical install
+graphical
+# Use CDROM installation media
+cdrom
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+# Network information
+network  --bootproto=dhcp --device=ens192 --ipv6=auto --activate
+network  --hostname=localhost.localdomain
+#Repo
+#url --url=http://mirror.centos.org/centos/7/os/x86_64/
+repo --name="AppStream" --baseurl=file:///run/install/repo/AppStream
+# Root password
+rootpw packerbuilt!
+# Run the Setup Agent on first boot
+firstboot --disable
+# Eula
+eula --agreed
+# Do not configure the X Window System
+skipx
+# Disable Firewall
+firewall --disabled
+# Selinux permissive
+selinux --permissive
+# System services
+services --enabled="chronyd,sshd"
+# System timezone
+timezone America/New_York --isUtc
+# Disk partitioning information
+part / --fstype="xfs" --ondisk=sda --size=20000 
+reboot
+user --name=packerbuilt --plaintext --password=packerbuilt! --groups=wheel
+
+%packages
+@^minimal-environment
+kexec-tools
+sudo
+net-tools
+vim
+wget
+curl
+cloud-init
+cloud-utils-growpart
+
+# unnecessary firmware
+-aic94xx-firmware
+-atmel-firmware
+-b43-openfwwf
+-bfa-firmware
+-ipw2100-firmware
+-ipw2200-firmware
+-ivtv-firmware
+-iwl100-firmware
+-iwl1000-firmware
+-iwl3945-firmware
+-iwl4965-firmware
+-iwl5000-firmware
+-iwl5150-firmware
+-iwl6000-firmware
+-iwl6000g2a-firmware
+-iwl6050-firmware
+-libertas-usb8388-firmware
+-ql2100-firmware
+-ql2200-firmware
+-ql23xx-firmware
+-ql2400-firmware
+-ql2500-firmware
+-rt61pci-firmware
+-rt73usb-firmware
+-xorg-x11-drv-ati-firmware
+-zd1211-firmware
+%end
+
+%addon com_redhat_kdump --enable --reserve-mb='auto'
+%end
+
+%anaconda
+pwpolicy root --minlen=6 --minquality=1 --notstrict --nochanges --notempty
+pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
+pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --notempty
+%end
+
+%post
+#yum update -y
+
+fallocate -l 2G /.swap
+chmod 0600 /.swap
+mkswap /.swap
+echo '/.swap    swap    swap    default    0   0' >> /etc/fstab
+
+sed "s/^ssh_pwauth.*/ssh_pwauth: True/g" -i /etc/cloud/cloud.cfg
+sed "s/PasswordAuthentication no/PasswordAuthentication yes/g" -i /etc/ssh/sshd_config
+echo "packerbuilt ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/packerbuilt
+sed -i "s/^.*requiretty/#Defaults requiretty/" /etc/sudoers
+
+#yum clean all
+%end

--- a/vSphere/rhel_8/readme.md
+++ b/vSphere/rhel_8/readme.md
@@ -1,0 +1,12 @@
+#Rhel 8 clean template
+This should build a usable Rancher Template
+
+It does have the code for an internal proxy - just remove that configuration if its not needed.
+
+Please edit the following:
+* script.sh
+* variables.json
+* rhel7.json
+
+Replace values for proxy (if needed), docker server repo if you have it local, domain names for subscription, and your local Red Hat Satellite Server if its on prem.
+

--- a/vSphere/rhel_8/rhel8.json
+++ b/vSphere/rhel_8/rhel8.json
@@ -1,0 +1,53 @@
+{
+  "builders": [
+    {
+      "CPUs": 2,
+      "RAM": 3192,
+      "RAM_reserve_all": true,
+      "boot_command": [
+        "<tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg<enter><wait>"
+      ],
+      "boot_order": "disk,cdrom",
+      "cluster": "{{user `cluster`}}",
+      "convert_to_template": "true",
+      "datastore": "{{user `datastore`}}",
+      "disk_controller_type": "pvscsi",
+      "folder": "{{user `folder`}}",
+      "guest_os_type": "centos7_64Guest",
+      "host": "{{user `host`}}",
+      "http_directory": "./http",
+      "insecure_connection": "true",
+      "iso_checksum": "SHA256:7fdfed9c7cced4e526a362e64ed06bcdc6ce0394a98625a40e7d05db29bf7b86",
+      "iso_urls": "http://<<your_repo_server>>/iso/rhel-8.2-x86_64-dvd.iso",
+      "network_adapters": [
+        {
+          "network": "{{user `network`}}",
+          "network_card": "vmxnet3"
+        }
+      ],
+      "password": "{{user `password`}}",
+      "ssh_password": "{{user `ssh_password`}}",
+      "ssh_username": "{{user `ssh_username`}}",
+      "storage": [
+        {
+          "disk_size": 20480,
+          "disk_thin_provisioned": true
+        }
+      ],
+      "type": "vsphere-iso",
+      "username": "{{user `username`}}",
+      "vcenter_server": "{{user `vcenter_server`}}",
+      "vm_name": "{{user `vm_image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "execute_command": "echo '{{user `ssh_password`}}' | sudo -S -E bash '{{.Path}}'",
+      "scripts": [
+        "script.sh"
+      ],
+      "type": "shell"
+    }
+  ]
+}
+

--- a/vSphere/rhel_8/script.sh
+++ b/vSphere/rhel_8/script.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# purge files to make sure since we are going to recreate them
+rm /etc/rhsm/facts/katello.facts
+rm /etc/yum.repos.d/docker.repo
+rm /etc/environment
+rm /etc/systemd/system/docker.service.d/https-proxy.conf
+rm /etc/profile.d/proxy.sh
+
+# Proxy stuff
+cat <<EOT >> /etc/profile.d/proxy.sh
+export HTTP_PROXY=http://<<proxy_server>>:8080
+export HTTPS_PROXY=http://<<proxy_server>>:8080
+export http_proxy=http://<<proxy_server>>:8080
+export https_proxy=http://<<proxy_server>>:8080
+EOT
+
+cat <<EOT >> /etc/environment
+http_proxy=http://<<proxy_server>>:8080
+https_proxy=http://<<proxy_server>>:8080
+HTTP_PROXY=http://<<proxy_server>>:8080
+HTTPS_PROXY=http://<<proxy_server>>:8080
+EOT
+
+mkdir /etc/systemd/system/docker.service.d
+cat <<EOT >> /etc/systemd/system/docker.service.d/https-proxy.conf
+[Service]
+Environment="HTTP_PROXY=http://<<proxy_server>>:8080/"
+Environment="HTTPS_PROXY=http://<<proxy_server>>:8080/"
+Environment="NO_PROXY=<<rancher_url>>,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+EOT
+
+# Do subscription manager stuff and update packages
+cat <<EOT >> /etc/rhsm/facts/katello.facts
+{"network.hostname-override":"<<yourdomain>>.local"}
+EOT
+
+rpm -Uvh http://<<your_rsat_server>>/pub/katello-ca-consumer-latest.noarch.rpm
+subscription-manager register --org="<<org_name>>" --activationkey='<<activation_key>>'
+subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms
+yum -y install vim nano net-tools bind-utils
+yum -y update
+
+cat <<EOT >> /etc/yum.repos.d/docker.repo
+[docker-ce-stable]
+name=Docker CE Stable - $basearch
+baseurl=http://<<your_repo_server>>/docker-ce-stable-upstream/
+failovermethod=priority
+enabled=1
+gpgcheck=0
+EOT
+
+yum clean packages
+yum clean metadata
+yum clean all
+
+yum -y install container-selinux
+#The upstream has an issue where containerd.io is hidden from the system in dnf
+#yum -y install containerd.io
+yum -y --disablerepo="*" --enablerepo=docker-ce-stable install http://<<your_repo_server>>/docker-ce-stable/Packages/containerd.io-1.2.13-3.2.el7.x86_64.rpm
+yum -y install docker-ce docker-ce-selinux
+systemctl daemon-reload
+service docker restart
+systemctl enable docker
+
+subscription-manager unregister
+
+docker run hello-world
+docker rm $(docker ps -a -f status=exited -f status=created -q)
+docker rmi $(docker images -a -q)
+
+# Reset the machine-id value. This has known to cause issues with DHCP
+#
+echo -n > /etc/machine-id
+
+# Reset any existing cloud-init state
+#
+cloud-init clean -s -l
+

--- a/vSphere/rhel_8/variables.json.example
+++ b/vSphere/rhel_8/variables.json.example
@@ -1,0 +1,13 @@
+{
+    "vcenter_server":"",
+    "username":"administrator@vsphere.local",
+    "password":"",
+    "datastore":"",
+    "folder": "",
+    "host":"",
+    "cluster": "",
+    "network": "",
+    "ssh_username": "root",
+    "ssh_password": "PackerBuilt!",
+    "vm_image_name" "rhel_8_packer_image"
+}


### PR DESCRIPTION
Here are modifications for RHEL 7 and RHEL 8 kickstart and packer builds. 

- I've added a variable for image name to make it easier to modify the image name itself.
- The image definitions also preinstall docker. For RHEL8 this has to be done due to a problem with the script upstream.
- The image definitions also work around the fact the docker upstream repo has a problem that hides containerd.io rpm. 

Within the templates I've added a quick README.

- These were built in an environment with a proxy server. I've included a basic proxy server field with notes in the script and json files.
- Most folks who use RHEL use some sort of Satellite server or have to point to one to pull updates and packages. I've added places to modify for this
- I've also added a place to pull the docker repo since cloning it internal is common in many organizations.
