### PR TITLE
[SLES] Switch to online GM and ensure install is deregistered

### DIFF
--- a/vSphere/sles_15_sp2/README.md
+++ b/vSphere/sles_15_sp2/README.md
@@ -2,10 +2,10 @@
 
 Before you use Packer to build this image, you need to do the following:
 
-* Download the SLES 15 SP2 ISO (`SLE-15-SP2-Full-x86_64-QU1-Media1.iso`) and drop
+* Download the SLES 15 SP2 'online' GM ISO (`SLE-15-SP2-Online-x86_64-GM-Media1.iso`) and drop
   it into this folder;
-* Update `autoinstall.xml` and amend line 281 to specify your registration code
+* Update `autoinstall.xml` and amend line 272 to specify your registration code
   so that various add-ons can be included.
 
-As with the other images, you may also want to change the default build user (`packerbuilt`) /
+As with the other openSUSE image, you may also want to change the default build user (`packerbuilt`) /
 password.

--- a/vSphere/sles_15_sp2/autoinst.xml
+++ b/vSphere/sles_15_sp2/autoinst.xml
@@ -1,15 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
-  <add-on>
-    <add_on_products config:type="list">
-      <listentry>
-        <media_url><![CDATA[dvd:///?devices=/dev/sr0]]></media_url>
-        <product>sle-module-basesystem-release</product>
-        <product_dir>/Module-Basesystem</product_dir>
-      </listentry>
-    </add_on_products>
-  </add-on>
   <bootloader>
     <global>
       <activate>true</activate>

--- a/vSphere/sles_15_sp2/install.sh
+++ b/vSphere/sles_15_sp2/install.sh
@@ -16,6 +16,8 @@ ln -s /etc/machine-id /var/lib/dbus/machine-id
 # Cleanup
 #
 zypper -n clean --all
+/usr/sbin/SUSEConnect --de-register
+zypper -n rr SLES15-SP2-15.2-0
 rm -f /etc/udev/rules.d/70-persistent-net.rules
 touch /etc/udev/rules.d/75-persistent-net-generator.rules
 truncate -s 0 /etc/{hostname,hosts,resolv.conf}
@@ -28,4 +30,3 @@ fi
 rm -rf /tmp/* /tmp/.* /var/tmp/* /var/tmp/.* &> /dev/null || true
 rm -rf /var/cache/*/* /var/crash/* /var/lib/systemd/coredump/*
 cloud-init clean -s -l
-

--- a/vSphere/sles_15_sp2/sles-15sp2.json
+++ b/vSphere/sles_15_sp2/sles-15sp2.json
@@ -10,6 +10,7 @@
         "netsetup=dhcp ",
         "lang=en_US ",
         "textmode=1 ",
+        "self_update=1 ",
         "autoyast=device://fd0/autoinst.xml",
         "<enter><wait>"
       ],
@@ -21,8 +22,8 @@
         "./autoinst.xml"
       ],
       "guest_os_type": "sles15_64Guest",
-      "iso_checksum": "64aea562b5f51381b57f0c295fdd96c49b64c5f0760f2b62752fca54f4d999fd",
-      "iso_urls": "./SLE-15-SP2-Full-x86_64-QU1-Media1.iso",
+      "iso_checksum": "6ac1d233aaeca29e7237ee462badeb8d2becc11dc508317cb27702a50f855541",
+      "iso_urls": "./SLE-15-SP2-Online-x86_64-GM-Media1.iso",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_port": 22,


### PR DESCRIPTION
Speed up the process by switching to a smaller ISO for installation, as well as using the GM release so that the `self_update` flag can be applied in order to work around [this issue](https://www.suse.com/support/kb/doc/?id=000019850).

Also deregister the installation once the build has completed, so no licenses are left orphaned.