### PR TITLE
Minor tweak for enabling cloud-config and cloud-final units at boot

### DIFF
--- a/vSphere/opensuse_leap_15.2/autoinst.xml
+++ b/vSphere/opensuse_leap_15.2/autoinst.xml
@@ -170,6 +170,8 @@ packerbuilt ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/packerbuilt
         <service>sshd</service>
         <service>docker</service>
         <service>cloud-init</service>
+        <service>cloud-config</service>
+        <service>cloud-final</service>
       </enable>
     </services>
   </services-manager>

--- a/vSphere/opensuse_leap_15.3/autoinst.xml
+++ b/vSphere/opensuse_leap_15.3/autoinst.xml
@@ -167,6 +167,8 @@ packerbuilt ALL=(ALL,ALL) NOPASSWD: ALL" > /etc/sudoers.d/packerbuilt
         <service>sshd</service>
         <service>docker</service>
         <service>cloud-init</service>
+        <service>cloud-config</service>
+        <service>cloud-final</service>
       </enable>
     </services>
   </services-manager>


### PR DESCRIPTION
Added additional services to be enabled in the opensuse autoinst.xml which will run cloud-config and cloud-final units.