### PR TITLE
ubuntu_2004/script-no-dhcp.sh: fix cleaning out no-dhcp change

### DIFF
--- a/vSphere/ubuntu_2004/customisation_scripts/script-no-dhcp.sh
+++ b/vSphere/ubuntu_2004/customisation_scripts/script-no-dhcp.sh
@@ -16,16 +16,17 @@ truncate -s 0 /etc/machine-id
 rm /var/lib/dbus/machine-id
 ln -s /etc/machine-id /var/lib/dbus/machine-id
 
-# Prevent cloud-init from setting IP
-#
-echo "Disabling cloud-init networking"
-bash -c "echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
-
 # Reset any existing cloud-init state
 #
 echo "Resetting Cloud-Init"
 rm /etc/cloud/cloud.cfg.d/*.cfg
 cloud-init clean -s -l
+
+# Prevent cloud-init from setting IP
+#
+echo "Disabling cloud-init networking"
+bash -c "echo 'network: {config: disabled}' > /etc/cloud/cloud.cfg.d/99-disable-network-config.cfg"
+
 
 echo "Removing existing Netplan config file"
 rm /etc/netplan/*.yaml


### PR DESCRIPTION
I noticed we add the cloud config file, and then delete it a few lines later.

Switching the order here should do the trick :)