### PR TITLE
Change url to Opensuse ISO

### DIFF
--- a/vSphere/opensuse_leap_15.3/opensuse-leap-15.3-x86_64.json
+++ b/vSphere/opensuse_leap_15.3/opensuse-leap-15.3-x86_64.json
@@ -21,8 +21,8 @@
         "./autoinst.xml"
       ],
       "guest_os_type": "sles15_64Guest",
-      "iso_checksum": "54fb3a488e0fececf45cdaeefaccfb64437745da4b1ca444662e3aac20cf37b5",
-      "iso_urls": "https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64.iso",
+      "iso_checksum": "40da6b6fd17f552cd5aa3526d1a5ee091a948c8890ca70d03c9f3f8caa2e0876",
+      "iso_urls": "https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso",
       "ssh_username": "{{user `ssh_username`}}",
       "ssh_password": "{{ user `ssh_password` }}",
       "ssh_port": 22,


### PR DESCRIPTION
Apparently the URL to get the Iso for opensuse Leap 15.3 has changed.
==> vsphere-iso: Trying https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64.iso
==> vsphere-iso: Trying https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64.iso?checksum=sha256%3A54fb3a488e0fececf45cdaeefaccfb64437745da4b1ca444662e3aac20cf37b5
==> vsphere-iso: Download failed bad response code: 404
==> vsphere-iso: error downloading ISO: [bad response code: 404]
Build 'vsphere-iso' errored after 3 seconds 349 milliseconds: error downloading ISO: [bad response code: 404]


It works with the following: 
==> vsphere-iso: Trying https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso
==> vsphere-iso: Trying https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-NET-x86_64-Current.iso?checksum=sha256%3A40da6b6fd17f552cd5aa3526d1a5ee091a948c8890ca70d03c9f3f8caa2e0876

