### PR TITLE
Amend disk layout for Ubuntu 20.04 so cloud-init can expand fs

### DIFF
--- a/vSphere/ubuntu_2004/http/user-data
+++ b/vSphere/ubuntu_2004/http/user-data
@@ -4,6 +4,34 @@ autoinstall:
   early-commands:
     - systemctl stop ssh # otherwise packer tries to connect and exceed max attempts
   locale: en_US
+  storage:
+    config:
+    - grub_device: true
+      id: disk-sda
+      path: /dev/sda
+      ptable: gpt
+      type: disk
+      wipe: superblock-recursive
+    - device: disk-sda
+      flag: bios_grub
+      id: partition-0
+      number: 1
+      size: 1048576
+      type: partition
+    - device: disk-sda
+      id: partition-1
+      number: 2
+      size: -1
+      type: partition
+      wipe: superblock
+    - fstype: ext4
+      id: format-0
+      type: format
+      volume: partition-1
+    - device: format-0
+      id: mount-0
+      path: /
+      type: mount
   keyboard:
       layout: en
       variant: uk

--- a/vSphere/ubuntu_2004/ubuntu-2004.json
+++ b/vSphere/ubuntu_2004/ubuntu-2004.json
@@ -25,7 +25,7 @@
 
       "storage": [
         {
-          "disk_size": 32768,
+          "disk_size": 8192,
           "disk_thin_provisioned": true
         }
       ],


### PR DESCRIPTION
The default disk layout for Ubuntu uses LVM, which leaves cloud-init unable to expand the root partition and filesystem to fill the remaining space when the size of disk is changed.

This commit adds a simple storage layout with a single partition for for `/`.