### PR TITLE
do not release IP leases and remove cd-rom from template

### DIFF
--- a/vSphere/ubuntu_2204/script.sh
+++ b/vSphere/ubuntu_2204/script.sh
@@ -22,3 +22,6 @@ ln -s /etc/machine-id /var/lib/dbus/machine-id
 echo "Reset Cloud-Init"
 rm /etc/cloud/cloud.cfg.d/*.cfg
 cloud-init clean -s -l
+
+# Do not notify the DHCP server to release leases on graceful shutdown
+/usr/bin/sed -i '/\[DHCPv4\]/a SendRelease=false' /etc/systemd/networkd.conf

--- a/vSphere/ubuntu_2204/ubuntu-2204.json
+++ b/vSphere/ubuntu_2204/ubuntu-2204.json
@@ -15,6 +15,7 @@
       "folder": "{{user `folder`}}",
       "iso_url": "https://releases.ubuntu.com/22.04.1/ubuntu-22.04.1-live-server-amd64.iso",
       "iso_checksum": "10f19c5b2b8d6db711582e0e27f5116296c34fe4b313ba45f9b201a5007056cb",
+      "remove_cdrom": true,
 
       "network_adapters": [
         {


### PR DESCRIPTION
Restarting a machine that is using DHCP could result in the IP address changing, which can break the k8s cluster. 

Also, the CD-ROM is most likely not necessary in the template and can cause issues with migrating VMs to different hosts in VCenter.